### PR TITLE
Docker integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "CourseFlow Development Container",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "frontend",
+	"workspaceFolder": "/frontend",
+	"shutdownAction": "stopCompose",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"johnpapa.Angular2",
+				"Angular.ng-template",
+				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
+				"johnpapa.vscode-peacock",
+				"johnpapa.winteriscoming",
+				"PKief.material-icon-theme"
+			]
+		}
+	}
+}

--- a/Frontend/course-flow-app/.dockerignore
+++ b/Frontend/course-flow-app/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/Frontend/course-flow-app/Dockerfile
+++ b/Frontend/course-flow-app/Dockerfile
@@ -1,0 +1,29 @@
+# Base image.
+FROM node:18-alpine
+
+# Create a variable for the working directory.
+ARG WORK_DIR=/frontend
+
+# Set this so that local node module executables can be called.
+ENV PATH ${WORK_DIR}/node_modules/.bin:$PATH
+
+# Set the base working directory for the container.
+RUN mkdir ${WORK_DIR}
+WORKDIR ${WORK_DIR}
+
+# Copy package files
+COPY package.json ${WORK_DIR}
+COPY package-lock.json ${WORK_DIR}
+
+# Run npm installs
+RUN npm install -g @angular/cli
+RUN npm install
+
+# Copy everything else - use the docker ignore file to ignore directories and files that you don't want copied over.
+COPY . ${WORK_DIR}
+
+# Expose port.
+EXPOSE 4200
+
+# Run ng serve on container creation - the poll will allow for hot reload to work.
+CMD ng serve --host 0.0.0.0 --poll=1000

--- a/Frontend/course-flow-app/angular.json
+++ b/Frontend/course-flow-app/angular.json
@@ -94,5 +94,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  frontend:
+    build:
+      context: ./frontend/course-flow-app
+      dockerfile: Dockerfile
+    container_name: course-flow-app
+    ports:
+      - '4200:4200'
+    volumes:
+      - ./frontend/course-flow-app:/frontend
+      - /frontend/node_modules


### PR DESCRIPTION
- Contains docker related files.

- Docker related files were created in a separate prototype project and brought into a cleaner branch (to help avoid merge conflicts).

- If validating:
    - Have Docker Desktop installed. 
    - Install Dev Containers plugin (Vs Code should prompt you to install it automatically.)
    - Click on the blue button on the bottom left and click "Reopen in Container" or click the same thing in the VS Code message 
       on the bottom right.
    - This will reopen vs-code in the container.
    - You will need to open up localhost:4200 to see the web app (didn't try to make it open automatically).